### PR TITLE
Fixing the build, first try

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,9 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    implementation ('androidx.test.espresso:espresso-contrib:3.4.0'){
+        exclude module: "protobuf-lite"
+    }
     implementation 'com.google.firebase:firebase-firestore:24.1.0'
     def fragment_version = "1.4.1"
 
@@ -59,17 +61,13 @@ dependencies {
 
     //Firebase google authentication setup
 
-    implementation platform('com.google.firebase:firebase-bom:29.3.0')
+    implementation platform('com.google.firebase:firebase-bom:29.1.0')
     implementation 'com.google.firebase:firebase-analytics'
     implementation 'com.google.firebase:firebase-auth'
-    implementation ('com.google.firebase:firebase-firestore:24.1.0'){
-        exclude group: 'com.google.protobuf', module: 'protobuf-javalite'
-    }
+    implementation 'com.google.firebase:firebase-firestore:24.1.0'
     implementation 'com.google.android.gms:play-services-auth:20.1.0'
 
     implementation "com.google.android.material:material:1.2.0-alpha3"
-
-
 
 
     debugImplementation "androidx.fragment:fragment-testing:$fragment_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
         <activity
             android:name=".ui.activities.ConversationsActivity"
             android:exported="true" />
+        <activity
+            android:name=".ui.activities.MealActivity"
+            android:exported="false" />
 
         <activity
             android:name=".ui.activities.ChatRoomActivity"

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+configurations {
+    scm
+}
+dependencies {
+    scm 'org.eclipse.jgit:org.eclipse.jgit:4.9.2.201712150930-r'
+    scm 'commons-codec:commons-codec:1.10'
+}
 buildscript {
     repositories {
         google()


### PR DESCRIPTION
The build now passes, but requires some reruns, the "fix" that was done was to exclude the protobuild from espresso contrib, which uses protlib 3.0.1, which makes conflicts with the version 3.19.0.2, used by firebase. The problem now is that the build fails a lot of times due to a "activity not launched" or "couldn't get focus on root view", which also happen locally. By searching on the internet, the problem seems like the test runner isn't able to properly launch the tests, which is probably due to the exclusion of the version used by espresso contrib. We'll have to look more into that, as for now this is only a hack but not a proper solution. We'll have to see about resolving dependency conflicts properly, instead of just making exclusions  